### PR TITLE
Update install documents to reflect PHP supported

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -36,7 +36,7 @@ Drupal Compatibility
 Drush Version | Drush Branch  | PHP | Compatible Drupal versions | Code Status
 ------------- | ---------     | --- | -------------------------- | -----------
 Drush 8       | [master](https://travis-ci.org/drush-ops/drush)  | 5.4.5+ | D6, D7, D8                 | <img src="https://travis-ci.org/drush-ops/drush.svg?branch=master">
-Drush 7       | [7.x](https://travis-ci.org/drush-ops/drush) | 5.3.0+ | D6, D7                     | <img src="https://travis-ci.org/drush-ops/drush.svg?branch=7.x">
+Drush 7       | [7.x](https://travis-ci.org/drush-ops/drush) | 5.4.0+ | D6, D7                     | <img src="https://travis-ci.org/drush-ops/drush.svg?branch=7.x">
 Drush 6       | [6.x](https://travis-ci.org/drush-ops/drush) | 5.3.0+ | D6, D7                     | Unsupported
 Drush 5       | [5.x](https://travis-ci.org/drush-ops/drush) | 5.2.0+ | D6, D7                     | Unsupported
 


### PR DESCRIPTION
Referencing #544 Drush does not support PHP 5.3. Let's make sure the documents reflect that.
